### PR TITLE
fix failing OSM coordinates in future_workshop_test

### DIFF
--- a/tests/testthat/test-get_future_workshops.R
+++ b/tests/testthat/test-get_future_workshops.R
@@ -24,6 +24,6 @@ test_that("Date selections are made using future argument", {
 test_that("Locations are found with Open Street Map", {
   load(file = "holytest.rda")
   holyselect <- get_future_workshops(holytest, future="none")
-  expect_equal(holyselect$latitude[3], 52.3566292)
-  expect_equal(holyselect$longitude[3], 4.9568662)
+  expect_equal(round(holyselect$latitude[3], 1), 52.4)
+  expect_equal(round(holyselect$longitude[3], 1), 5.0)
 })


### PR DESCRIPTION
The `get_future_workshops` test for Open Street Map coordinates fails because of a change in the decimals of the exact coordinates. To prevent this failure, the test now rounds the coordinates to 1 decimal.

(Code by @liekelotte, advancing this to incorporate it in more PRs than just #23 🙃)