### PR TITLE
increase get_meta_url robustness

### DIFF
--- a/R/get_comms_doc_info.R
+++ b/R/get_comms_doc_info.R
@@ -13,7 +13,7 @@
 #'
 get_comms_doc_info <- function(info) {
 
-  meta_url <- get_meta_url(info$slug)
+  meta_url <- get_meta_url(info)
 
   comm_doc_info <- list(YYYYMMDD              = as.character(info$startdate),
                         slug                  = info$slug,

--- a/R/get_meta_url.R
+++ b/R/get_meta_url.R
@@ -1,32 +1,70 @@
 #' Get meta folder
 #'
-#' Take the slug and return the corresponding URL where the meta files live for
-#' the workshop in question.
+#' Take the workshop info and return the corresponding URL where the meta files
+#' live for the workshop in question.
 #'
-#' @param slug workshop slug
+#' @param info workshop information named vector
 #'
 #' @return url to the folder containing workshop metadata
-get_meta_url <- function(slug) {
-  # delete date from the slug
-  slug <- stringr::str_remove(slug, "^\\d{4}-\\d{2}-\\d{2}-")
+get_meta_url <- function(info) {
 
-  # some metadata URLs that are different from their slug
-  if(slug == "ds-geospatial"){
-    slug <- "ds-geospatial-python"
-  }
-  if(slug == "dc-astronomy-python"){
-    slug <- "dc-astronomy"
+  slug <- info$curriculum
+  meta_url <- check_slug(slug)
+
+  if(class(meta_url) == "character"){
+    return(meta_url)
   }
 
+  slug <- make_slug_option1(info)
+  meta_url <- check_slug(slug)
+
+  if(class(meta_url) == "character"){
+    return(meta_url)
+  }
+
+  slug <- make_slug_option2(info)
+  meta_url <- check_slug(slug)
+
+  if(class(meta_url) == "character"){
+    return(meta_url)
+  }
+
+  slug <- make_slug_option3(info)
+  meta_url <- check_slug(slug)
+
+  if(class(meta_url) == "character"){
+    return(meta_url)
+  }
+
+  stop(paste("The information for workshop", info$slug, "is not linked to any meta URL."))
+}
+
+make_slug_option1 <- function(info){
+  slug <- paste(info$curriculum, info$flavor, sep = "-")
+  return(slug)
+}
+
+make_slug_option2 <- function(info){
+  slug <- stringr::str_remove(info$slug, "^\\d{4}-\\d{2}-\\d{2}-")
+  return(slug)
+}
+
+make_slug_option3 <- function(info){
+  # this should not be necessary!
+  # the flavor argument 'python' is added, because the holyexcel did not include it
+  slug <- paste(info$curriculum, "python", sep = "-")
+  return(slug)
+}
+
+
+
+check_slug <- function(slug){
   ghraw <- "https://raw.githubusercontent.com/esciencecenter-digital-skills/workshop-metadata/main/"
   meta_url <- paste0(ghraw,slug,"/")
-
-  # check if the URL exists by pinging the Title page
   title <- paste0(meta_url, "title.md")
   if(!RCurl::url.exists(title)){
-    stop(paste("The slug", slug, "is not linked to any URL. Perhaps you misspelled it?"))
+    return(FALSE)
+  } else{
+    return(meta_url)
   }
-
-  return(meta_url)
-
 }

--- a/tests/testthat/test-get_meta.R
+++ b/tests/testthat/test-get_meta.R
@@ -1,19 +1,36 @@
 test_that("get_meta_url", {
+  load("infotest.rda")
+  expect_equal(get_meta_url(infotest),
+               "https://raw.githubusercontent.com/esciencecenter-digital-skills/workshop-metadata/main/ds-dl-intro/")
 
-  expect_equal(get_meta_url("ds-parallel"),
+  info <- data.frame(curriculum = "ds-parallel", flavor = NA)
+  expect_equal(get_meta_url(info),
                             "https://raw.githubusercontent.com/esciencecenter-digital-skills/workshop-metadata/main/ds-parallel/")
 
-  expect_equal(get_meta_url("ds-docker"),
+  info <- data.frame(curriculum = "ds-docker", flavor = NA)
+  expect_equal(get_meta_url(info),
                             "https://raw.githubusercontent.com/esciencecenter-digital-skills/workshop-metadata/main/ds-docker/")
 
-  expect_equal(get_meta_url("ds-rpackaging"),
+  info <- data.frame(curriculum = "ds-rpackaging", flavor = NA)
+  expect_equal(get_meta_url(info),
                             "https://raw.githubusercontent.com/esciencecenter-digital-skills/workshop-metadata/main/ds-rpackaging/")
 
-  expect_equal(get_meta_url("ds-gpu"),
+  info <- data.frame(curriculum = "ds-gpu", flavor = NA)
+  expect_equal(get_meta_url(info),
                             "https://raw.githubusercontent.com/esciencecenter-digital-skills/workshop-metadata/main/ds-gpu/")
 
-  expect_equal(get_meta_url("dc-socsci-python"),
+  info <- data.frame(curriculum = "dc-socsci", flavor = "python")
+  expect_equal(get_meta_url(info),
                             "https://raw.githubusercontent.com/esciencecenter-digital-skills/workshop-metadata/main/dc-socsci-python/")
+
+  info <- data.frame(curriculum = "ds-geospatial", flavor = "python")
+  expect_equal(get_meta_url(info),
+               "https://raw.githubusercontent.com/esciencecenter-digital-skills/workshop-metadata/main/ds-geospatial-python/")
+
+  info <- data.frame(curriculum = "dc-astronomy", flavor = "python")
+  expect_equal(get_meta_url(info),
+               "https://raw.githubusercontent.com/esciencecenter-digital-skills/workshop-metadata/main/dc-astronomy/")
+
 
   expect_error(get_meta_url("wrong-slug"))
 


### PR DESCRIPTION
This PR changes the functionality behind `get_meta_url` to use other fields from the holy excel to find the curriculum metadata.
This matches the way a slug is created in the holy excel sheet (namely from `curriculum` and `flavor`), and it becomes more robust against different ways of storing the curriculum, because it is verified to be a functional URL before being returned.

Closes #41 