### PR TITLE
Fix notification issue for some team members

### DIFF
--- a/tests/testthat/test-get_people.R
+++ b/tests/testthat/test-get_people.R
@@ -8,14 +8,14 @@ test_that("People are identified as Instructors team members", {
                              instr_team)
 
   expect_true(is.list(team_members))
-  expect_equal(length(team_members), 4)
+  expect_equal(length(team_members), 4) ## 2 teachers in infotest + 2 people in alert
   expect_true("ms_team_member" %in% class(team_members[[1]]))
 })
 
 test_that("When people cannot be identified, the program reports this.", {
   errorps <- "Person Notemployed"
 
-  expect_message(get_people(infotest,
+  expect_warning(get_people(infotest,
                             alert = errorps,
                             instr_team),
                  regexp = "Cannot find team member Person Notemployed")
@@ -23,20 +23,19 @@ test_that("When people cannot be identified, the program reports this.", {
 })
 
 test_that("Some people who were not alerted in the past are identified correctly.",{
-  infotest$lead_instructor <- "Sarah Alidoost"
-  infotest$supporting_instructor1 <- "Giulia Crocioni"
-  infotest$supporting_instructor2 <- "Laura Ootes"
-  infotest$helper1 <- "Fakhereh (Sarah) Alidoost"
-  infotest$helper2 <- "Barbara Vreede"
-  infotest$helper3 <- NA
 
   team_members <- get_people(infotest,
-                             alert = NA,
+                             alert = c("Heli Jarvenpaa",
+                                       "Giulia Crocioni",
+                                       "Laura Ootes",
+                                       "Thijs van Lankeveld",
+                                       "Pablo Rodríguez-Sánchez",
+                                       "Carlos Murilo Rocha"),
                              instr_team)
 
   expect_true(is.list(team_members))
-  expect_equal(length(team_members), 3)
   expect_true("ms_team_member" %in% class(team_members[[1]]))
+  expect_equal(length(team_members), 8) # 2 people in infotest + 6 names in alert
 
 })
 


### PR DESCRIPTION
This PR adds more flexibility to finding the team member from the name in the holy excel sheet. Not all names in the sheet match the person's Microsoft name (e.g. extra spaces between first and last name, missing accents, or what have you). Here I'm adding very basic "fuzzy" matching, which accepts a max Levenshtein distance of 4 between a name in the list of members from the Instructors Team on MS, and the name as given by the Holy Excel sheet.

The other functionality this adds, is that if there is no Microsoft name found that clearly matches with the Holy Excel name, this is reported; a training coordinator can now manually alert this person on Teams.

Test the workflow (sorry, poor R packaging channel) as follows:

```
old_workshop <- traininginfrastructure::read_from_drive() |> traininginfrastructure::get_future_workshops(future = "none")
old_r_workshop <- old_workshop[3,]
old_r_workshop$helper1 <- NA
old_r_workshop$helper2 <- NA
old_r_workshop$helper3 <- NA
old_r_workshop$supporting_instructor1 <- NA
save_post_sharepoint(old_r_workshop, alert=c("Laura Ootes", "Giulia Crocioni"))
```
This should make a post in the channel for 2023-03-08-ds-rpackaging (confirm the channel by running `old_r_workshop$slug`) that calls both Laura and Giulia. You should also get a message in the console that their names are not in the Microsoft teams list, but that a close match was found.

(Laura and Giulia were the names that initally were reported not to be alerted; see #53.)

Fixes #53 