### PR TITLE
Check system settings

### DIFF
--- a/R/get_comms_doc_info.R
+++ b/R/get_comms_doc_info.R
@@ -12,6 +12,7 @@
 #' @export
 #'
 get_comms_doc_info <- function(info) {
+  check_location_setting()
 
   meta_url <- get_meta_url(info)
 
@@ -43,4 +44,10 @@ get_comms_doc_info <- function(info) {
                         repo_ref              = paste0("[workshop repository](","https://github.com/esciencecenter-digital-skills/", info$slug, "/files" ,")"),
                         show_text             = TRUE)
   return(comm_doc_info)
+}
+
+check_location_setting <- function(){
+  location <- Sys.getlocale()
+  #grepl("en", location)
+  #"en_US.UTF-8/en_US.UTF-8/en_US.UTF-8/C/en_US.UTF-8/en_US.UTF-8"
 }


### PR DESCRIPTION
When creating the communication docs, the system settings determine the language of the "humandates". This can cause problems when these are in a different language than English; as happened with @FenneRiemslagh (https://github.com/esciencecenter-digital-skills/training-infrastructure/issues/65).

This PR checks whether the system settings are good, and warns the user if they are not.


(This PR is the correct one; PR #69 was made from the wrong branch, apologies!)